### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://conceptinc.visualstudio.com/9245e3b8-644c-45bb-adbe-9876948251cb/5ff5911e-fc87-4ea1-bce0-7a6538eeb848/_apis/work/boardbadge/58ac6a84-53fb-4c84-9793-16589891b975)](https://conceptinc.visualstudio.com/9245e3b8-644c-45bb-adbe-9876948251cb/_boards/board/t/5ff5911e-fc87-4ea1-bce0-7a6538eeb848/Microsoft.RequirementCategory)
 [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#12](https://conceptinc.visualstudio.com/9245e3b8-644c-45bb-adbe-9876948251cb/_workitems/edit/12). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.